### PR TITLE
Fix typo in word config, which leads to the volume not being found

### DIFF
--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -31,7 +31,7 @@ spec:
             - secretRef:
                 name:  fip-controller-secrets
           volumeMounts:
-            - name: conifg
+            - name: config
               mountPath: /app/config
       serviceAccountName: fip-controller
       volumes:


### PR DESCRIPTION
Before the volume could not be mounted with the example deployment due to a typo in the volumeMounts section.

Also added a newline at the end of the file.