### PR TITLE
Add DaemonSet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ commands
 ```
 $ kubectl create namespace fip-controller
 $ kubectl apply -f deploy/rbac.yaml
-$ kubectl applf -f deploy/deployment.yaml
+$ kubectl apply -f deploy/deployment.yaml
 $ cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
@@ -96,8 +96,7 @@ stringData:
 
 Alternatively, you can run the controller as a DaemonSet.
 This ensures one controller will run on each worker node.
-
-Instead of executing `$ kubectl applf -f deploy/deployment.yaml`, execute `$ kubectl applf -f deploy/daemonset.yaml`.
+Instead of executing `$ kubectl apply -f deploy/deployment.yaml`, execute `$ kubectl apply -f deploy/daemonset.yaml`.
 
 ## Multiple controller
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,11 @@ stringData:
   HCLOUD_API_TOKEN: <hcloud_api_token>
 ```
 
+Alternatively, you can run the controller as a DaemonSet.
+This ensures one controller will run on each worker node.
+
+Instead of executing `$ kubectl applf -f deploy/deployment.yaml`, execute `$ kubectl applf -f deploy/daemonset.yaml`.
+
 ## Multiple controller
 
 The controller can be installed multiple times, e.g. to handle IP-addresses

--- a/deploy/daemonset.yaml
+++ b/deploy/daemonset.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: fip-controller
+  namespace: fip-controller
+spec:
+  selector:
+    matchLabels:
+      app: fip-controller
+  template:
+    metadata:
+      labels:
+        app: fip-controller
+    spec:
+      containers:
+        - name: fip-controller
+          image: cbeneke/hcloud-fip-controller:v0.2.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          envFrom:
+            - secretRef:
+                name:  fip-controller-secrets
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+      serviceAccountName: fip-controller
+      volumes:
+        - name: config
+          configMap:
+            name: fip-controller-config


### PR DESCRIPTION
In case you only need a single set of controllers, it might be nice to schedule them as DaemonSet instead of Deployment. This will prevent that all controllers could get scheduled on a single worker node.

The deployment was using v0.2.1. Therefore I also used this version for the DaemonSet. I'll create a new issue to bump the version.

Edit: #24 created