### PR TITLE
Unassign floating IPs before reassigning them to fix occasional race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+* v0.3.3
+  * Fix race condition when reassigning IPs to another node resulting in the IPs becoming unreachable
+
 * v0.3.2
   * Fix parameter validation
 

--- a/deploy/daemonset.yaml
+++ b/deploy/daemonset.yaml
@@ -14,7 +14,7 @@ spec:
     spec:
       containers:
         - name: fip-controller
-          image: cbeneke/hcloud-fip-controller:v0.3.2
+          image: cbeneke/hcloud-fip-controller:v0.3.3
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME

--- a/deploy/deployment.yaml
+++ b/deploy/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: fip-controller
-          image: cbeneke/hcloud-fip-controller:v0.3.2
+          image: cbeneke/hcloud-fip-controller:v0.3.3
           imagePullPolicy: IfNotPresent
           env:
             - name: NODE_NAME

--- a/internal/app/fipcontroller/controller.go
+++ b/internal/app/fipcontroller/controller.go
@@ -109,13 +109,22 @@ func (controller *Controller) UpdateFloatingIPs(ctx context.Context) error {
 		controller.Logger.Debugf("Checking floating IP: %s", floatingIP.IP.String())
 
 		if floatingIP.Server == nil || server.ID != floatingIP.Server.ID {
-			controller.Logger.Infof("Switching address '%s' to server '%s'", floatingIP.IP.String(), server.Name)
-			_, response, err := controller.HetznerClient.FloatingIP.Assign(ctx, floatingIP, server)
+			controller.Logger.Infof("Unassigning address '%s'", floatingIP.IP.String())
+			_, response, err := controller.HetznerClient.FloatingIP.Unassign(ctx, floatingIP)
 			if err != nil {
-				return fmt.Errorf("could not update floating IP '%s': %v", floatingIP.IP.String(), err)
+				return fmt.Errorf("could not unassign floating IP '%s': %v", floatingIP.IP.String(), err)
 			}
 			if response.StatusCode != 201 {
-				return fmt.Errorf("could not update floating IP '%s': Got HTTP Code %d, expected 201", floatingIP.IP.String(), response.StatusCode)
+				return fmt.Errorf("could not unassign floating IP '%s': Got HTTP Code %d, expected 201", floatingIP.IP.String(), response.StatusCode)
+			}
+
+			controller.Logger.Infof("Assigning address '%s' to server '%s'", floatingIP.IP.String(), server.Name)
+			_, response, err := controller.HetznerClient.FloatingIP.Assign(ctx, floatingIP, server)
+			if err != nil {
+				return fmt.Errorf("could not assign floating IP '%s': %v", floatingIP.IP.String(), err)
+			}
+			if response.StatusCode != 201 {
+				return fmt.Errorf("could not assign floating IP '%s': Got HTTP Code %d, expected 201", floatingIP.IP.String(), response.StatusCode)
 			}
 		}
 	}


### PR DESCRIPTION
This PR is related to https://github.com/cbeneke/hcloud-fip-controller/issues/36.

It unassigns the floating IPs before reassigning them. This ensure that reassignment works consistently.

I am not too familiar with Go but it seemed like a small change, so I hope it's OK.

Thanks!