### PR TITLE
Show undefinedErrors if any exist.

### DIFF
--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -48,7 +48,7 @@ func (config *Configuration) Validate() error {
 	}
 
 	if len(undefinedErrs) > 0 {
-		errs = append(errs, fmt.Sprintf("required configuration options not configured: %s", strings.Join(errs, ", ")))
+		errs = append(errs, fmt.Sprintf("required configuration options not configured: %s", strings.Join(undefinedErrs, ", ")))
 	}
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, ", "))


### PR DESCRIPTION
Currently when having undefinedErrors, the application only prints out
"normal" errors.
This bugfix makes sure to append the undefinedErrors to the error list
if there are any.

Fix #45 