### PR TITLE
Make lease renewDeadline configurable

### DIFF
--- a/cmd/fip-controller/main.go
+++ b/cmd/fip-controller/main.go
@@ -22,7 +22,8 @@ func main() {
 	flag.Var(&controllerConfig.NodeAddressType, "node-address-type", "Kubernetes node address type")
 
 	flag.StringVar(&controllerConfig.HcloudApiToken, "hcloud-api-token", "", "Hetzner cloud API token")
-	flag.IntVar(&controllerConfig.LeaseDuration, "lease-duration", 30, "Time to wait (in seconds) until next leader check")
+	flag.IntVar(&controllerConfig.LeaseDuration, "lease-duration", 15, "Time to wait (in seconds) until next leader check")
+	flag.IntVar(&controllerConfig.LeaseRenewDeadline, "lease-renew-deadline", 10, "Time to wait (in seconds) until next leader check")
 	flag.StringVar(&controllerConfig.LeaseName, "lease-name", "fip", "Name of the lease lock for leaderelection")
 	flag.StringVar(&controllerConfig.Namespace, "namespace", "", "Kubernetes Namespace")
 	flag.StringVar(&controllerConfig.NodeName, "node-name", "", "Kubernetes Node name")

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,7 @@ Name of the lease created by the lease lock used for leader election
 
 * LEASE_DURATION, *default:* 15
 Duration of the lease used by the lease lock. This is the maximum time until a new leader will be elected in case of failure.
+More about the leaderelection variables can be found [here](https://godoc.org/k8s.io/client-go/tools/leaderelection).
 
 * LEASE_RENEW_DEADLINE, *default* 10
 Duration that the master will retry refreshing its leadership before giving up.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,8 +13,12 @@ Floating IP you want to configure. In case of IPv6 can be any of the /64 net. If
 * LEASE_NAME, *default:* "fip"  
 Name of the lease created by the lease lock used for leader election
 
-* LEASE_DURATION, *default:* 30  
+* LEASE_DURATION, *default:* 15
 Duration of the lease used by the lease lock. This is the maximum time until a new leader will be elected in case of failure.
+
+* LEASE_RENEW_DEADLINE, *default* 10
+Duration that the master will retry refreshing its leadership before giving up.
+Must be smaller than LEASE_DURATION
 
 * LOG_LEVEL, *default*: Info  
 Log level of the controller.

--- a/internal/app/fipcontroller/leaderelection.go
+++ b/internal/app/fipcontroller/leaderelection.go
@@ -29,7 +29,7 @@ func (controller *Controller) leaderElectionConfig() (config leaderelection.Lead
 		Lock:            controller.leaseLock(controller.Configuration.PodName),
 		ReleaseOnCancel: true,
 		LeaseDuration:   time.Duration(controller.Configuration.LeaseDuration) * time.Second,
-		RenewDeadline:   15 * time.Second,
+		RenewDeadline:   time.Duration(controller.Configuration.LeaseRenewDeadline) * time.Second,
 		RetryPeriod:     5 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: controller.onStartedLeading,

--- a/internal/app/fipcontroller/leaderelection.go
+++ b/internal/app/fipcontroller/leaderelection.go
@@ -30,7 +30,7 @@ func (controller *Controller) leaderElectionConfig() (config leaderelection.Lead
 		ReleaseOnCancel: true,
 		LeaseDuration:   time.Duration(controller.Configuration.LeaseDuration) * time.Second,
 		RenewDeadline:   time.Duration(controller.Configuration.LeaseRenewDeadline) * time.Second,
-		RetryPeriod:     5 * time.Second,
+		RetryPeriod:     2 * time.Second,
 		Callbacks: leaderelection.LeaderCallbacks{
 			OnStartedLeading: controller.onStartedLeading,
 			OnStoppedLeading: controller.onStoppedLeading,

--- a/internal/pkg/configuration/configuration.go
+++ b/internal/pkg/configuration/configuration.go
@@ -43,8 +43,15 @@ func (config *Configuration) Validate() error {
 	if config.Namespace == "" {
 		undefinedErrs = append(errs, "kubernetes namespace")
 	}
+
 	if config.LeaseDuration <= 0 {
-		errs = append(errs, "lease duration needs to be greater than one")
+		errs = append(errs, "lease duration needs to be greater than 0")
+	}
+	if config.LeaseRenewDeadline <= 0 {
+		errs = append(errs, "lease renew deadline needs to be greater than 0")
+	}
+	if config.LeaseRenewDeadline >= config.LeaseDuration {
+		errs = append(errs, "lease renew deadline needs to be smaller than lease duration")
 	}
 
 	if len(undefinedErrs) > 0 {

--- a/internal/pkg/configuration/types.go
+++ b/internal/pkg/configuration/types.go
@@ -6,15 +6,16 @@ import (
 )
 
 type Configuration struct {
-	HcloudApiToken    string           `json:"hcloud_api_token,omitempty"`
-	HcloudFloatingIPs stringArrayFlags `json:"hcloud_floating_ips,omitempty"`
-	LeaseDuration     int              `json:"lease_duration,omitempty"`
-	LeaseName         string           `json:"lease_name,omitempty"`
-	Namespace         string           `json:"namespace,omitempty"`
-	NodeAddressType   NodeAddressType  `json:"node_address_type,omitempty"`
-	NodeName          string           `json:"node_name,omitempty"`
-	PodName           string           `json:"pod_name,omitempty"`
-	LogLevel          string           `json:"log_level,omitempty"`
+	HcloudApiToken     string           `json:"hcloud_api_token,omitempty"`
+	HcloudFloatingIPs  stringArrayFlags `json:"hcloud_floating_ips,omitempty"`
+	LeaseDuration      int              `json:"lease_duration,omitempty"`
+	LeaseRenewDeadline int              `json:"lease_renew_deadline,omitempty"`
+	LeaseName          string           `json:"lease_name,omitempty"`
+	Namespace          string           `json:"namespace,omitempty"`
+	NodeAddressType    NodeAddressType  `json:"node_address_type,omitempty"`
+	NodeName           string           `json:"node_name,omitempty"`
+	PodName            string           `json:"pod_name,omitempty"`
+	LogLevel           string           `json:"log_level,omitempty"`
 }
 
 // Set of string flags


### PR DESCRIPTION
Add a new configuration entry that allow to set the duration the current leader will try to renew its leadership. (This value must always be smaller than LEASE_DURATION)

Additionally set the default duration according to https://godoc.org/k8s.io/client-go/tools/leaderelection#LeaderElectionConfig

LEASE_DURATION: 15
LEASE_RENEW_DEADLINE: 10