### PR TITLE
Fixed domain of helm-charts repo in docs

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -4,7 +4,7 @@
 Install helm in the latest version and add the cbeneke/helm-charts repo
 
 ```
-$ helm repo add cbeneke https://cbeneke.github.com/helm-charts
+$ helm repo add cbeneke https://cbeneke.github.io/helm-charts
 $ helm repo update
 ```
 


### PR DESCRIPTION
cbeneke.github.com does no longer exist. It's cbeneke.github.io now.

Thanks to https://giters.com/cbeneke/hcloud-fip-controller/issues/61#issuecomment-931274045