### PR TITLE
List only running Pods (fix #64)

### DIFF
--- a/internal/app/fipcontroller/kubernetes.go
+++ b/internal/app/fipcontroller/kubernetes.go
@@ -40,6 +40,7 @@ func (controller *Controller) nodeAddressList(ctx context.Context, nodeAddressTy
 	// Try to get deployment pods if certain label is specified
 	listOptions := metav1.ListOptions{}
 	listOptions.LabelSelector = podLabelSelector
+	listOptions.FieldSelector = "status.phase=Running"
 	var pods *corev1.PodList
 
 	err = retry.OnError(controller.Backoff, alwaysRetry, func() error {


### PR DESCRIPTION
This PR fixes Issue #64 . 

It filters for Running Pods, because Pending Pods have no IP address.