### PR TITLE
Require floating IPs and API token explicitly in Helm chart

### DIFF
--- a/.github/workflows/helm.yaml
+++ b/.github/workflows/helm.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: azure/setup-helm@v4
 
       - name: Helm lint
-        run: helm lint deploy --strict --set hcloudApiToken=dummy
+        run: helm lint deploy --strict --set hcloudApiToken=dummy --set 'floatingIPs={1.2.3.4}'
 
       - name: Install kubeconform
         run: |
@@ -42,6 +42,7 @@ jobs:
             helm template fip deploy \
               --namespace fip-controller \
               --set hcloudApiToken=dummy \
+              --set 'floatingIPs={1.2.3.4}' \
               --set kind="${kind}" \
               | kubeconform -strict -summary \
                   -schema-location default \

--- a/deploy/templates/NOTES.txt
+++ b/deploy/templates/NOTES.txt
@@ -3,15 +3,11 @@
 Release:   {{ .Release.Name }}
 Namespace: {{ .Release.Namespace }}
 
-{{- if and (not .Values.existingSecretName) (not .Values.hcloudApiToken) }}
-
-WARNING: No Hetzner Cloud API token was configured.
-The controller expects a secret named "{{ include "hcloud-fip-controller.secretName" . }}"
-with an HCLOUD_API_TOKEN key. Set `hcloudApiToken` or `existingSecretName` in
-your values, or create the secret manually:
-
-  kubectl -n {{ .Release.Namespace }} create secret generic {{ include "hcloud-fip-controller.secretName" . }} \
-    --from-literal=HCLOUD_API_TOKEN=<your-token>
+API token secret: {{ include "hcloud-fip-controller.secretName" . }}
+{{ if .Values.floatingIPs -}}
+Managing {{ len .Values.floatingIPs }} floating IP(s) from the chart configuration.
+{{- else -}}
+Floating IPs are auto-discovered from the Hetzner Cloud API.
 {{- end }}
 
 Check the controller status with:

--- a/deploy/templates/configmap.yaml
+++ b/deploy/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.floatingIPs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "hcloud-fip-controller.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "hcloud-fip-controller.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {{- dict "hcloud_floating_ips" .Values.floatingIPs | toPrettyJson | nindent 4 }}
+{{- end }}

--- a/deploy/templates/controller.yaml
+++ b/deploy/templates/controller.yaml
@@ -1,3 +1,9 @@
+{{- if and (not .Values.hcloudApiToken) (not .Values.existingSecretName) }}
+{{- fail "A Hetzner Cloud API token is required: set `hcloudApiToken` or point `existingSecretName` at a secret containing an HCLOUD_API_TOKEN key." }}
+{{- end }}
+{{- if and (not .Values.floatingIPs) (not .Values.floatingIPAutodiscovery) }}
+{{- fail "No floating IPs configured: set `floatingIPs` to the addresses to manage, or set `floatingIPAutodiscovery: true` to auto-discover them from the Hetzner Cloud API." }}
+{{- end }}
 apiVersion: apps/v1
 kind: {{ .Values.kind }}
 metadata:
@@ -68,10 +74,22 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "hcloud-fip-controller.secretName" . }}
+          {{- if .Values.floatingIPs }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config
+              readOnly: true
+          {{- end }}
           {{- with .Values.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.floatingIPs }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "hcloud-fip-controller.fullname" . }}-config
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -24,12 +24,26 @@ rbac:
   # Create the ClusterRole and ClusterRoleBinding required by the controller.
   create: true
 
-# Hetzner Cloud API token. When set (and existingSecretName is empty), a Secret
-# holding HCLOUD_API_TOKEN is created by the chart.
+# Hetzner Cloud API token (REQUIRED). When set (and existingSecretName is
+# empty), a Secret holding HCLOUD_API_TOKEN is created by the chart.
+# Either hcloudApiToken or existingSecretName must be provided.
 hcloudApiToken: ""
 # Name of an existing secret containing an HCLOUD_API_TOKEN key. When set, the
 # chart will not create its own secret.
 existingSecretName: ""
+
+# Floating IPs to manage (REQUIRED unless floatingIPAutodiscovery is true).
+# Rendered into a ConfigMap (config.json) that is mounted into the controller.
+# IPv6 may be any address of the /64 net. Example:
+#   floatingIPs:
+#     - 1.2.3.4
+#     - 2001:db8::1
+floatingIPs: []
+
+# When true, the controller auto-discovers floating IPs from the Hetzner Cloud
+# API and floatingIPs may be left empty. Set this explicitly to opt out of
+# managing an explicit list.
+floatingIPAutodiscovery: false
 
 # Additional controller configuration rendered as environment variables.
 # See docs/configuration.md for all available options. Example:

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -14,20 +14,28 @@ $ helm install hcloud-fip-controller \
     oci://registry-1.docker.io/cbeneke/hcloud-fip-controller \
     --namespace fip-controller \
     --create-namespace \
-    --set hcloudApiToken=<hcloud_api_token>
+    --set hcloudApiToken=<hcloud_api_token> \
+    --set 'floatingIPs={1.2.3.4}'
 ```
 
 Use `--version <x.y.z>` to pin a specific chart version (the chart version
 matches the application version).
 
+The chart **requires** a Hetzner Cloud API token and the floating IPs to
+manage. Installation fails fast if neither `hcloudApiToken` nor
+`existingSecretName` is set, or if `floatingIPs` is empty and
+`floatingIPAutodiscovery` is not enabled.
+
 Alternatively, install the chart directly from a checkout of this repository.
-Provide your Hetzner Cloud API token and let the chart create the namespace:
+Provide your Hetzner Cloud API token and floating IPs, and let the chart create
+the namespace:
 
 ```
 $ helm install hcloud-fip-controller ./deploy \
     --namespace fip-controller \
     --create-namespace \
-    --set hcloudApiToken=<hcloud_api_token>
+    --set hcloudApiToken=<hcloud_api_token> \
+    --set 'floatingIPs={1.2.3.4}'
 ```
 
 Alternatively, supply your own values file:
@@ -48,7 +56,28 @@ that contains an `HCLOUD_API_TOKEN` key instead of letting the chart create one:
 $ helm install hcloud-fip-controller ./deploy \
     --namespace fip-controller \
     --create-namespace \
-    --set existingSecretName=my-hcloud-secret
+    --set existingSecretName=my-hcloud-secret \
+    --set 'floatingIPs={1.2.3.4}'
+```
+
+### Floating IPs
+
+The floating IPs to manage are configured via the `floatingIPs` list. The chart
+renders them into a ConfigMap (`config.json`) that is mounted into the
+controller:
+
+```yaml
+floatingIPs:
+  - 1.2.3.4
+  - 2001:db8::1
+```
+
+To let the controller auto-discover floating IPs from the Hetzner Cloud API
+instead of managing an explicit list, leave `floatingIPs` empty and opt in
+explicitly:
+
+```yaml
+floatingIPAutodiscovery: true
 ```
 
 ### Using a DaemonSet
@@ -86,8 +115,10 @@ The most relevant chart values are:
 | `replicaCount`      | `3`                            | Replicas (Deployment only)                        |
 | `image.repository`  | `cbeneke/hcloud-fip-controller`| Container image repository                        |
 | `image.tag`         | `""`                           | Image tag, defaults to `v<appVersion>`            |
-| `hcloudApiToken`    | `""`                           | Hetzner Cloud API token (creates a Secret)        |
+| `hcloudApiToken`    | `""`                           | Hetzner Cloud API token, required (creates a Secret) |
 | `existingSecretName`| `""`                           | Use an existing secret with `HCLOUD_API_TOKEN`    |
+| `floatingIPs`       | `[]`                           | Floating IPs to manage; required unless autodiscovery |
+| `floatingIPAutodiscovery` | `false`                  | Auto-discover floating IPs instead of an explicit list |
 | `config`            | `{}`                           | Extra controller options as environment variables |
 | `healthCheck.port`  | `8080`                         | Port for the liveness/readiness endpoints         |
 
@@ -100,5 +131,6 @@ manifests directly:
 $ kubectl create namespace fip-controller
 $ helm template hcloud-fip-controller ./deploy \
     --namespace fip-controller \
-    --set hcloudApiToken=<hcloud_api_token> | kubectl apply -f -
+    --set hcloudApiToken=<hcloud_api_token> \
+    --set 'floatingIPs={1.2.3.4}' | kubectl apply -f -
 ```


### PR DESCRIPTION
## Summary

Makes the two things the controller cannot run without — the Hetzner Cloud API token and the floating IPs — explicit, validated chart values instead of relying on a manually-created secret/configmap.

- **API token**: the chart now `fail`s at render time if neither `hcloudApiToken` nor `existingSecretName` is set (previously the pod would start with a dangling `secretRef` and crash).
- **Floating IPs**: new `floatingIPs` list value, rendered into a ConfigMap (`config.json`) and mounted at `/app/config` (supports multiple IPs, incl. IPv6). The chart `fail`s if `floatingIPs` is empty unless `floatingIPAutodiscovery: true` is set explicitly (preserving the controller's auto-discovery feature as an explicit opt-in).
- Helm CI (`helm.yaml`) updated to pass `floatingIPs` so lint/template/kubeconform still pass.
- `docs/deploy.md` and the NOTES updated.

## Behavior

| Values | Result |
|--------|--------|
| no token | render fails with a clear message |
| token, no `floatingIPs`, no autodiscovery | render fails with a clear message |
| token + `floatingIPs` | ConfigMap created and mounted |
| token + `floatingIPAutodiscovery: true` | no ConfigMap; controller auto-discovers |

## Test plan
- [x] `helm lint --strict`
- [x] `helm template` for all four scenarios above
- [x] kubeconform validation (Deployment + DaemonSet, 6/6 resources valid)

Made with [Cursor](https://cursor.com)