### PR TITLE
Treat dependencies label as a patch release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,14 +41,20 @@ jobs:
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             bump="${{ github.event.inputs.bump }}"
           else
-            # Read the semver label from the PR associated with this merge commit.
+            # Read the labels from the PR associated with this merge commit.
+            # An explicit semver label wins; a "dependencies" label (e.g. added
+            # by Renovate) is treated as a patch release.
             labels="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
               --jq '.[].labels[].name' 2>/dev/null || true)"
+            explicit=""
+            deps=""
             for label in ${labels}; do
               case "${label}" in
-                major|minor|patch) bump="${label}" ;;
+                major|minor|patch) explicit="${label}" ;;
+                dependencies) deps="patch" ;;
               esac
             done
+            bump="${explicit:-${deps}}"
           fi
           if [ -z "${bump}" ]; then
             echo "No semver label found; defaulting to patch"

--- a/.github/workflows/semver-label.yaml
+++ b/.github/workflows/semver-label.yaml
@@ -42,10 +42,12 @@ jobs:
             exit 0
           fi
 
+          # A "dependencies" label (added automatically by Renovate) counts as
+          # a patch release, so no suggestion is needed in that case either.
           current="$(gh pr view "${PR}" --repo "${REPO}" --json labels \
-            --jq '[.labels[].name | select(. == "patch" or . == "minor" or . == "major")] | length')"
+            --jq '[.labels[].name | select(. == "patch" or . == "minor" or . == "major" or . == "dependencies")] | length')"
           if [ "${current}" != "0" ]; then
-            echo "Semver label already present, leaving it untouched."
+            echo "Semver (or dependencies) label already present, leaving it untouched."
             exit 0
           fi
 
@@ -87,16 +89,26 @@ jobs:
 
           labels="$(gh pr view "${PR}" --repo "${REPO}" --json labels \
             --jq '[.labels[].name | select(. == "patch" or . == "minor" or . == "major")] | join(" ")')"
+          deps="$(gh pr view "${PR}" --repo "${REPO}" --json labels \
+            --jq '[.labels[].name | select(. == "dependencies")] | length')"
           count="$(echo ${labels} | wc -w | tr -d ' ')"
+
+          if [ "${count}" -gt 1 ]; then
+            echo "::error::Multiple semver labels set (${labels}). Keep exactly one of: patch, minor, major."
+            exit 1
+          fi
 
           if [ "${count}" -eq 1 ]; then
             echo "Found semver label: ${labels}"
             exit 0
           fi
 
-          if [ "${count}" -eq 0 ]; then
-            echo "::error::No semver label set. Add exactly one of: patch, minor, major."
-          else
-            echo "::error::Multiple semver labels set (${labels}). Keep exactly one of: patch, minor, major."
+          # No explicit semver label: a "dependencies" label (e.g. from
+          # Renovate) is treated as a patch release.
+          if [ "${deps}" != "0" ]; then
+            echo "Found dependencies label, treated as a patch release."
+            exit 0
           fi
+
+          echo "::error::No semver label set. Add exactly one of: patch, minor, major (or 'dependencies' for a patch release)."
           exit 1


### PR DESCRIPTION
## Summary

Renovate automatically adds a `dependencies` label to its PRs but no semver label, so the `semver-label` check failed (and blocked auto-merge). This makes `dependencies` count as a patch release.

- **semver-label check**: a PR with the `dependencies` label (and no explicit semver label) now passes, treated as a patch release. An explicit `patch`/`minor`/`major` label still takes precedence; multiple explicit semver labels still fail. The AI suggestion step also skips when `dependencies` is present.
- **release workflow**: the bump resolution maps `dependencies` -> patch (explicit semver labels win).

No Renovate config change is needed (it already applies the `dependencies` label).

## Test plan
- [x] Workflow YAML validated
- [x] Enforcement + bump logic simulated for: none, dependencies-only, explicit, dependencies+explicit, multiple explicit

Made with [Cursor](https://cursor.com)