### PR TITLE
Authorize release chart-bump commit via GitHub App token

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,21 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      # Mint a token from the release GitHub App so the chart-version commit
+      # can bypass the "require pull request" branch ruleset on main. The App
+      # is added to the ruleset bypass list (see repo settings -> rules).
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Determine next version
         id: version


### PR DESCRIPTION
## Summary

The release pipeline failed at the "Commit chart version" step because it pushes the chart-version bump directly to `main`, which the branch ruleset ("require a pull request") rejects for the default `GITHUB_TOKEN`:

```
remote: - Changes must be made through a pull request.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
```

This mints a token from a dedicated release GitHub App and uses it for `checkout`, so the push is authorized.

## Configuration (already in place)
- Repo secrets `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`.
- The App is on the `main` ruleset bypass list (Integration actor, `bypass_mode: always`).

## Notes
- The App is scoped to **Contents: write** only.
- `[skip ci]` on the bump commit still prevents the release workflow from re-triggering itself.

## Test plan
- [ ] Merge a labeled PR to `main` and confirm the release workflow's chart-bump commit pushes successfully.

Made with [Cursor](https://cursor.com)