### PR TITLE
Only release when app code or Helm chart changes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,15 @@ on:
   push:
     branches:
       - main
+    # Only cut a release when the application code or the Helm chart changes.
+    # Docs, CI workflows and other repo files do not trigger a release.
+    # workflow_dispatch below still allows forcing a manual release.
+    paths:
+      - '**/*.go'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Dockerfile'
+      - 'deploy/**'
   workflow_dispatch:
     inputs:
       bump:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,7 @@ on:
     # workflow_dispatch below still allows forcing a manual release.
     paths:
       - '**/*.go'
+      - '!**/*_test.go'
       - 'go.mod'
       - 'go.sum'
       - 'Dockerfile'


### PR DESCRIPTION
## Summary

Restricts the release pipeline so a new version is cut only when something releasable actually changed, via `push` path filters on `main`:

- `**/*.go`, `go.mod`, `go.sum`, `Dockerfile` — application code / image
- `deploy/**` — the Helm chart

Pushes that only touch docs, CI workflows, or other repo files no longer trigger a release.

## Notes
- `workflow_dispatch` (manual release) is unaffected by path filters, so you can still force a release.
- The automated `chore(release): vX [skip ci]` commit touches `deploy/Chart.yaml` (matches `deploy/**`), but `[skip ci]` still prevents it from re-triggering the workflow.

## Test plan
- [ ] Merge a docs-only PR -> Release workflow does not run.
- [ ] Merge a code/chart PR -> Release workflow runs.

Made with [Cursor](https://cursor.com)